### PR TITLE
[tk76] Permitir que o slug_name seja editável

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -77,7 +77,8 @@ class Pages(Document):
         if not self.created_at:
             self.created_at = datetime.now()
         self.updated_at = datetime.now()
-        self.slug_name = slugify(self.name)
+        if not self.slug_name or slugify(self.slug_name) != self.slug_name:
+            self.slug_name = slugify(self.slug_name or self.name)
         return super(Pages, self).save(*args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.48',
+    version='2.49',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="scielo@scielo.org",

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -2,6 +2,7 @@
 from time import sleep
 from opac_schema.v1.models import Pages
 from .base import BaseTestCase
+from mongoengine.errors import ValidationError
 
 
 class TestPagesModel(BaseTestCase):
@@ -46,3 +47,72 @@ class TestPagesModel(BaseTestCase):
 
         # then
         self.assertTrue(initial_updated_at < final_updated_at)
+
+    def test_slug_name(self):
+        # given
+        _id = self.generate_uuid_32_string()
+        page_data = {
+            '_id': _id,
+            'name': 'foo boo',
+            'language': 'en',
+            'content': 'lorem ipsum',
+        }
+
+        # when
+        page_doc = Pages(**page_data)
+        page_doc.save()
+
+        # then
+        self.assertEqual(page_doc.slug_name, 'foo-boo')
+
+    def test_slug_name_informed_by_user_but_is_not_slugified(self):
+        # given
+        _id = self.generate_uuid_32_string()
+        page_data = {
+            '_id': _id,
+            'name': 'foo boo',
+            'language': 'en',
+            'content': 'lorem ipsum',
+            'slug_name': 'PÁGINA 1',
+        }
+
+        # when
+        page_doc = Pages(**page_data)
+        page_doc.save()
+
+        # then
+        self.assertEqual(page_doc.slug_name, 'pagina-1')
+
+    def test_slug_name_informed_by_user(self):
+        # given
+        _id = self.generate_uuid_32_string()
+        page_data = {
+            '_id': _id,
+            'name': 'foo boo',
+            'language': 'en',
+            'content': 'lorem ipsum',
+            'slug_name': 'pagina-2',
+        }
+
+        # when
+        page_doc = Pages(**page_data)
+        page_doc.save()
+
+        # then
+        self.assertEqual(page_doc.slug_name, 'pagina-2')
+
+    def test_name_is_not_informed(self):
+        # given
+        _id = self.generate_uuid_32_string()
+        page_data = {
+            '_id': _id,
+            'language': 'en',
+            'content': 'lorem ipsum',
+            'slug_name': 'pagina-2',
+        }
+
+        # when
+        page_doc = Pages(**page_data)
+
+        # then
+        self.assertRaises(ValidationError, page_doc.save)


### PR DESCRIPTION

O slug_name estava sendo gerado a partir do name.
Melhor que o usuário possa informar o valor para slug_name.
No entanto, o valor de slug_name, também deve ser "slugified", ou seja, se o usuário informar "Página 1" como slug_name, convertê-lo para "pagina-1".

Fixes #76