### PR TITLE
Modificações no model.Pages para não gerar slug_name automaticamente

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -77,7 +77,8 @@ class Pages(Document):
         if not self.created_at:
             self.created_at = datetime.now()
         self.updated_at = datetime.now()
-        self.slug_name = slugify(self.name)
+        if not self.slug_name:
+            self.slug_name = slugify(self.name)
         return super(Pages, self).save(*args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.49',
+    version='2.51',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="scielo@scielo.org",


### PR DESCRIPTION
#### O que esse PR faz?
* Modificação necessário para que nas paginas segundarias do OPAC, não seja sempre gerado o `slug_name`, so caso esse campo esteja em branco
* Também mudei a versão do `setup.py` para a próxima tag a ser criada 

#### Onde a revisão poderia começar?
pode começar pelo arquivo `models.py` na Classe `Pages`

#### Como este poderia ser testado manualmente?
Apos atualizar o `opac_schema` do `opac`, tenta mudar a slug de uma pagina e ao salvar ela permanecer e não ser alterada automaticamente 

#### Quais são tickets relevantes?
scieloorg/opac#1130
