### PR TITLE
Adiciona novo campo 'aop_url_segs' em 'Article'

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -254,6 +254,14 @@ class Sponsor(Document):
         return self.name
 
 
+class AOPUrlSegments(EmbeddedDocument):
+    url_seg_article = StringField()
+    url_seg_issue = StringField()
+
+    def __unicode__(self):
+        return "%s/%s" % (self.url_seg_issue, self.url_seg_article)
+
+
 class Collection(Document):
     _id = StringField(max_length=32, primary_key=True, required=True)
     acronym = StringField(max_length=50, required=True, unique=True)
@@ -612,6 +620,7 @@ class Article(Document):
     fpage_sequence = StringField()
     lpage = StringField()
     url_segment = StringField()
+    aop_url_segs = EmbeddedDocumentField(AOPUrlSegments)
 
     meta = {
         'collection': 'article',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.51',
+    version='2.52',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="scielo@scielo.org",


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona EmbeddedDocument `AOPUrlSegments` e novo campo 'aop_url_segs' em 'Article', que deve conter os url_segments do periódico e do artigo de um Ahead of Print no Ex-ahead.

#### Onde a revisão poderia começar?
Em `opac_schema/v1/models.py`, a classe `AOPUrlSegments`.

#### Como este poderia ser testado manualmente?
Deve ser possível instanciar `Article` passando o atributo `aop_url_segs`.

#### Algum cenário de contexto que queira dar?
Este campo é necessário para que, ao acessar o artigo com a URL de Ahead, seja possível chegar no Ex-ahead.

#### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac_proc/issues/409

#### Referências
Nenhuma.