### PR TITLE
Adiciona campo scielo_pids em Article p/ PIDs SciELO

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -621,6 +621,7 @@ class Article(Document):
     lpage = StringField()
     url_segment = StringField()
     aop_url_segs = EmbeddedDocumentField(AOPUrlSegments)
+    scielo_pids = DictField()
 
     meta = {
         'collection': 'article',
@@ -640,6 +641,7 @@ class Article(Document):
             'lpage',
             'url_segment',
             'elocation',
+            'scielo_pids',
         ]
     }
 
@@ -722,6 +724,8 @@ class Article(Document):
         }
 
         document.url_segment = URLegendarium(**leg_dict).get_article_seg()
+        if document.pid is None or len(document.pid) == 0:
+            document.pid = document.scielo_pids.get("v2")
 
     @property
     def legend(self):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     classifiers=[],
     install_requires=[
         "blinker",
-        "mongoengine<=0.15.3",
+        "mongoengine",
         "python-slugify",
         "legendarium",
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     classifiers=[],
     install_requires=[
         "blinker",
-        "mongoengine",
+        "mongoengine<=0.15.3",
         "python-slugify",
         "legendarium",
     ],

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -232,3 +232,101 @@ class TestArticleModel(BaseTestCase):
         # then
         self.assertEqual('o1111', article_doc.url)
 
+    def test_check_article_scielo_pids(self):
+        # given
+        # create a journal
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+
+        _id = self.generate_uuid_32_string()
+        aid = self.generate_uuid_32_string()
+        article_data = {
+            '_id': _id,
+            'aid': aid,
+            'is_public': True,
+            # requerido pelo Legendarium:
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'scielo_pids': {
+                "v1": "S0101-0202(98)01100123",
+                "v2": "S0101-02022019000300001",
+                "v3": "azEglOE290cWcmloijsd",
+            },
+        }
+
+        # when
+        article_doc = Article(**article_data)
+        article_doc.save()
+
+        # then
+        self.assertEqual(
+            article_doc.scielo_pids,
+            {
+                "v1": "S0101-0202(98)01100123",
+                "v2": "S0101-02022019000300001",
+                "v3": "azEglOE290cWcmloijsd",
+            }
+        )
+
+    def test_check_article_pid(self):
+        # given
+        # create a journal
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+
+        _id = self.generate_uuid_32_string()
+        aid = self.generate_uuid_32_string()
+        article_data = {
+            '_id': _id,
+            'aid': aid,
+            'is_public': True,
+            # requerido pelo Legendarium:
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'scielo_pids': {
+                "v1": "S0101-0202(98)01100123",
+                "v2": "S0101-02022019000300001",
+                "v3": "azEglOE290cWcmloijsd",
+            },
+        }
+
+        # when
+        article_doc = Article(**article_data)
+        article_doc.save()
+
+        # then
+        self.assertEqual(article_doc.pid, "S0101-02022019000300001")
+
+    def test_check_article_pid_already_set(self):
+        # given
+        # create a journal
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+
+        _id = self.generate_uuid_32_string()
+        aid = self.generate_uuid_32_string()
+        article_data = {
+            '_id': _id,
+            'aid': aid,
+            'is_public': True,
+            # requerido pelo Legendarium:
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'pid': "S0101-02022019000300123",
+            'scielo_pids': {
+                "v1": "S0101-0202(98)01100123",
+                "v2": "S0101-02022019000300001",
+                "v3": "azEglOE290cWcmloijsd",
+            },
+        }
+
+        # when
+        article_doc = Article(**article_data)
+        article_doc.save()
+
+        # then
+        self.assertEqual(article_doc.pid, "S0101-02022019000300123")
+


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona campo `scielo_pids` em `models.Article` para armazenar os PIDs SciELO existentes para o documento. Este campo deverá ser preenchido e, caso não haja valor explicitamente atribuído ao campo `pid`, assumirá o valor do PID `scielo-v2` para manter a compatibilidade com os sistemas atuais.

#### Onde a revisão poderia começar?
Em `opac_schema/v1/models.py`

#### Como este poderia ser testado manualmente?
Executando `python setup.py test -s tests.test_article`
ou
Criando uma instância de `models.Article` com o campo `scielo_pids`, verificar:
- que o campo `scielo_pids` mantém um campo dicionário
- que, ao salvar, o campo `pid` assume o valor de `scielo_pids["v2"]`
- que, caso o campo `pid` tenha um valor explicitamente atribuído, este valor deve ser mantido após salvar o modelo

#### Algum cenário de contexto que queira dar?
Detalhes em scieloorg/opac-airflow/issues/138

#### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac-airflow/issues/138

#### Referências
https://github.com/scieloorg/kernel/blob/master/docs/adr/0006-novo-pid-do-scielo.md
