### PR TITLE
Garante que o campo editor_email seja texto.

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -14,7 +14,6 @@ from mongoengine import (
     BooleanField,
     URLField,
     DictField,
-    EmailField,
     # reverse_delete_rule:
     PULL,
     CASCADE,
@@ -342,7 +341,7 @@ class Journal(Document):
     publisher_address = StringField()
     publisher_telephone = StringField()
     current_status = StringField()
-    editor_email = EmailField()
+    editor_email = StringField()
     enable_contact = BooleanField(default=False)
 
     mission = EmbeddedDocumentListField(Mission)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.53',
+    version='2.54',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="scielo@scielo.org",

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from six import string_types
 from opac_schema.v1.models import Journal
 from .base import BaseTestCase
 
@@ -28,3 +29,21 @@ class TestJournalModel(BaseTestCase):
         self.assertEqual(_id, journal_doc._id)
         self.assertEqual(jid, journal_doc.jid)
         self.assertEqual(1, Journal.objects.all().count())
+
+    def test_if_editor_email_field_accept_text(self):
+        _id = self.generate_uuid_32_string()
+        jid = self.generate_uuid_32_string()
+        journal_data = {
+            '_id': _id,
+            'jid': jid,
+            'title': 'The Dummy Journal Editor_email',
+            'acronym': 'dj',
+            'is_public': True,
+            'scimago_id': '4500151524',
+            'editor_email': 'example1@emial.com;example2@emial.com;'
+        }
+
+        journal_doc = Journal(**journal_data)
+        journal_doc.save()
+
+        self.assertTrue(isinstance(journal_doc.editor_email, string_types))


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR realiza a alteração do campo editor_email de EmailField para StringField, garantindo que possamos adiciona mais de um e-mail nesse campo.

#### Onde a revisão poderia começar?

No módulo opac_schema/v1/models.py: **344**

#### Como este poderia ser testado manualmente?

É possível realizar os teste executando a suite de teste: 

```python setup.py test```

Foi inserido um novo teste em **test_journal.py**

#### Algum cenário de contexto que queira dar?

Essa alteração foi motivada pelo ticket: https://github.com/scieloorg/opac_proc/issues/523

#### Screenshots

N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac_proc/issues/523
https://github.com/scieloorg/opac_schema/issues/85

#### Referências

N/A