### PR TITLE
Adiciona campo `display_full_text` ao schema de Artigo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ python:
   - "3.5"
   - "3.6"
 script:
+  - pip install -r requirements.txt
   - python setup.py test -q --verbose

--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -621,6 +621,7 @@ class Article(Document):
     url_segment = StringField()
     aop_url_segs = EmbeddedDocumentField(AOPUrlSegments)
     scielo_pids = DictField()
+    display_full_text = BooleanField(required=True, default=True)
 
     meta = {
         'collection': 'article',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+blinker==1.4
+legendarium==2.0.6
+mongoengine==0.18.2
+pymongo==3.10.1
+python-slugify==4.0.0
+six==1.14.0
+text-unidecode==1.3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     classifiers=[],
     install_requires=[
         "blinker",
-        "mongoengine",
+        "mongoengine<0.20",
         "python-slugify",
         "legendarium",
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.54',
+    version='2.55',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="scielo@scielo.org",

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -330,3 +330,35 @@ class TestArticleModel(BaseTestCase):
         # then
         self.assertEqual(article_doc.pid, "S0101-02022019000300123")
 
+    def test_if_display_full_text_is_true_by_default(self):
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+        article_data = {
+            '_id': self.generate_uuid_32_string(),
+            'aid': self.generate_uuid_32_string(),
+            'is_public': True,
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'pid': "S0101-02022019000300123"
+        }
+        article_doc = Article(**article_data)
+        article_doc.save()
+        self.assertTrue(article_doc.display_full_text)
+
+    def test_if_display_full_text_could_be_setted_as_false(self):
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+        article_data = {
+            '_id': self.generate_uuid_32_string(),
+            'aid': self.generate_uuid_32_string(),
+            'is_public': True,
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'pid': "S0101-02022019000300123",
+            'display_full_text': False
+        }
+        article_doc = Article(**article_data)
+        article_doc.save()
+        self.assertFalse(article_doc.display_full_text)


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona campo necessário para armazenar a decisão de exibição ou não do texto completo de artigos pelo Website.

#### Onde a revisão poderia começar?
- `opac_schema/v1/models.py` L: `624`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Rodar os testes automatizado;
- Iniciar um sessão do interpretador Python;
- Criar um novo documento utilizando o Opac Schema;
- Verificar a obrigatoriedade e o valor padrão do campo _display_full_text_ como `True`;

#### Algum cenário de contexto que queira dar?
N/A

#### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac/issues/1579

#### Referências
N/A