### PR TITLE
Tk90 - Adicionar a capacidade de armazenar metadados dos autores

### DIFF
--- a/opac_schema/v1/models.py
+++ b/opac_schema/v1/models.py
@@ -143,6 +143,39 @@ class Mission(EmbeddedDocument):
         return '%s: %s' % (self.language, self.description)
 
 
+class AuthorMeta(EmbeddedDocument):
+    """
+    Model responsable for author metadata.
+
+    Example of this model:
+
+        "author_meta" : [
+            {
+                "name" : "Thales Silva Coutinho",
+                "affiliation" : "Universidade Federal de Pernambuco",
+                "orcid" : "0000-0002-2173-4340",
+            },
+            {
+                "name" : "Matheus Colli-Silva",
+                "affiliation" : "Universidade de São Paulo",
+                "orcid" : "0000-0001-7130-3920",
+            },
+
+        ],
+
+    """
+    name = StringField()
+    affiliation = StringField()
+    orcid = StringField()
+
+    meta = {
+        'collection': 'author_meta'
+    }
+
+    def __unicode__(self):
+        return '%s - %s - %s' % (self.name, self.affiliation, self.orcid)
+
+
 class Abstract(EmbeddedDocument):
     language = StringField()
     text = StringField()
@@ -586,6 +619,7 @@ class Article(Document):
     section = StringField()
     sections = EmbeddedDocumentListField(TranslatedSection)
     authors = ListField(field=StringField())
+    authors_meta = EmbeddedDocumentListField(AuthorMeta)
     abstract = StringField()
     abstracts = EmbeddedDocumentListField(Abstract)
     is_aop = BooleanField()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="Opac Schema",
-    version='2.57',
+    version='2.58',
     description="Schema of SciELO OPAC",
     author="SciELO",
     author_email="dev@scielo.org",

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -362,3 +362,36 @@ class TestArticleModel(BaseTestCase):
         article_doc = Article(**article_data)
         article_doc.save()
         self.assertFalse(article_doc.display_full_text)
+
+    def test_if_possible_set_author_meta_attribute(self):
+        journal_doc = self._create_dummy_journal()
+        issue_doc = self._create_dummy_issue(journal_doc)
+
+        author_meta = [
+           {
+                "name": "Thales Silva Coutinho",
+                "affiliation": "Universidade Federal de Pernambuco",
+                "orcid": "0000-0002-2173-4340",
+            },
+           {
+                "name": "Matheus Colli-Silva",
+                "affiliation": "Universidade de São Paulo",
+                "orcid": "0000-0001-7130-3920",
+            },
+        ]
+
+        article_data = {
+            '_id': self.generate_uuid_32_string(),
+            'aid': self.generate_uuid_32_string(),
+            'is_public': True,
+            'journal': journal_doc,
+            'issue': issue_doc,
+            'order': 1111,
+            'pid': "S0101-02022019000300123",
+            'display_full_text': False,
+            'authors_meta': author_meta,
+        }
+
+        article_doc = Article(**article_data)
+        article_doc.save()
+        self.assertTrue(article_doc.authors_meta)


### PR DESCRIPTION
#### O que esse PR faz?

Adicionar a capacidade de armazenar metadados dos autores.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Sugiro rodar os testes automáticos.

```shell
python setup.py test
```

#### Algum cenário de contexto que queira dar?

Esse PR somente adicionar um novo campo no modelo, não, há qualquer adição de dados nesse novo campo.

Ticket: https://github.com/scieloorg/opac_schema/issues/90