### PR TITLE
Adiciona campo aid em ArticleFiles

### DIFF
--- a/opac_schema/v2/models.py
+++ b/opac_schema/v2/models.py
@@ -57,6 +57,7 @@ class ArticleFiles(Document):
     - zip para download com respectivos URI, nome do arquivo e anotações
     """
     aid = StringField(max_length=32, required=True)
+    scielo_pids = DictField()
     file = EmbeddedDocumentField(RemoteAndLocalFile)
     created = DateTimeField()
     updated = DateTimeField()


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona em ArticleFiles campo aid que é PID V3, mas não é a PrimaryKey.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
1. Instanciar um objeto ArticleFiles via python shell
2. Verificar que o campo _id é gerado pela mongoengine (e não é mais o PID v3)
3. Verificar que o campo aid é o PID v3
4. Verificar que o campo scielo_pids guarda um dicionário de PIDs, assim como há para o modelo Article (pode ser interessante, no futuro, buscar um pacote com base nos outros PIDs).

#### Algum cenário de contexto que queira dar?
N/A

#### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

#### Referências
N/A